### PR TITLE
Keeps selection set via .setSelected persistent

### DIFF
--- a/src/components/SearchResultMap/Map/Map.svelte
+++ b/src/components/SearchResultMap/Map/Map.svelte
@@ -26,8 +26,6 @@
 
   let map; // MapLibre map instance
 
-  let ready = false; // Data ready?
-
   let selection = null;
 
   let hovered = null;
@@ -113,8 +111,6 @@
   }
 
   const onMapClicked = evt => {
-    selected = undefined;
-    
     const bbox = [
       [evt.point.x - CLICK_THRESHOLD, evt.point.y - CLICK_THRESHOLD],
       [evt.point.x + CLICK_THRESHOLD, evt.point.y + CLICK_THRESHOLD]


### PR DESCRIPTION
## In this PR

This PR changes the behavior of the `.setSelection` method. The selection will now remain persistent until it is reset (by setting `.setSelection(undefined)`. If another marker is clicked (opening a different popup), and, afterward, the original marker is clicked again, the popup will again open at the selected position, with the selected record highlighted.

